### PR TITLE
Add default values to pydantic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 ## What is geeknn?
 
 `geeknn` is a package for running k-nearest neighbor (kNN) imputation using Google Earth Engine as a backend.
+
+## Installation
+
+`geeknn` will be available through PyPI and conda-forge once it is ready for release. Until then, you can install it from source.
+
+```bash
+pip install git+https://github.com/lemma-osu/gee-knn-python@main
+```
+
+## Dependencies
+
+- Python >= 3.9
+- earthengine-api
+- joblib
+- numpy
+- pydantic
+- scikit-learn
+- scikit-learn-knn-regression @ git+https://github.com/lemma-osu/scikit-learn-knn-regression@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [{ name = "Matt Gregory", email = "matt.gregory@oregonstate.edu" }]
 dependencies = [
     "earthengine-api",
     "joblib",
+    "numpy",
     "pydantic",
     "scikit-learn",
     "scikit-learn-knn-regression @ git+https://github.com/lemma-osu/scikit-learn-knn-regression",
@@ -45,7 +46,7 @@ coverage = "pytest --cov=src/geeknn {args}"
 allow-direct-references = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 select = [
     "E",
     "I",
@@ -66,3 +67,7 @@ show-fixes = true
 
 [tool.ruff.isort]
 known-first-party = ["geeknn"]
+
+[tool.pytest.ini_options]
+pythonpath = "src/"
+markers = ["slow: marks tests as slow-running"]

--- a/src/geeknn/_base.py
+++ b/src/geeknn/_base.py
@@ -26,7 +26,7 @@ class Feature(BaseModel):
     """Client-side proxy for ee.Feature object."""
 
     type: str
-    geometry: Optional[Geometry]  # noqa: UP007
+    geometry: Optional[Geometry] = None  # noqa: UP007
     id: str
     properties: dict[str, Any]
 
@@ -42,9 +42,9 @@ class FeatureCollection(BaseModel):
 
     type: str
     columns: dict[str, Any]
-    version: Optional[int]  # noqa: UP007
-    id: Optional[str]  # noqa: UP007
-    properties: Optional[dict[str, Any]]  # noqa: UP007
+    version: Optional[int] = None  # noqa: UP007
+    id: Optional[str] = None  # noqa: UP007
+    properties: Optional[dict[str, Any]] = None  # noqa: UP007
     features: list[Feature]
 
     def aggregate_array(self, property: str) -> NDArray:

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -1,0 +1,20 @@
+import ee
+
+from geeknn._base import FeatureCollection
+
+ee.Initialize()
+
+
+def test_feature_collection_missing_attributes():
+    fc_server = ee.FeatureCollection(
+        [
+            ee.Feature(ee.Geometry.Point([-123, 44]), {"foo": 1}),
+            ee.Feature(ee.Geometry.Point([-122, 44]), {"foo": 2}),
+            ee.Feature(ee.Geometry.Point([-121, 44]), {"foo": 3}),
+        ]
+    )
+    fc_client = FeatureCollection.from_ee_feature_collection(fc_server)
+    assert len(fc_client.features) == 3
+    assert fc_client.version is None
+    assert fc_client.id is None
+    assert fc_client.properties is None

--- a/tests/test_model_fc.py
+++ b/tests/test_model_fc.py
@@ -24,6 +24,7 @@ def run_method(kls, options, training_data, colocation_obj=None):
     return model.predict(training_data["fc"].limit(10), colocation_obj=colocation_obj)
 
 
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     "estimator_parameter",
     ESTIMATOR_PARAMETERS.values(),
@@ -40,6 +41,7 @@ def test_dependent(estimator_parameter, k, training_data, observed_ids):
     assert all(x == y for x, y in zip(observed_ids, prd))
 
 
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     "estimator_parameter",
     ESTIMATOR_PARAMETERS.values(),

--- a/tests/test_model_spatial.py
+++ b/tests/test_model_spatial.py
@@ -41,6 +41,7 @@ def run_method(kls, options, training_data, X_image, check_image):
     )
 
 
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     "estimator_parameter",
     ESTIMATOR_PARAMETERS.items(),


### PR DESCRIPTION
Closes #6 by adding default values to optional attributes (currently all set to `None`).  

Other small changes:
- Adds simple test for client-side `FeatureCollection`
- Marks some tests as "slow" to avoid long local testing times
- Provide some documentation for working with package in `README.md`
- Add `numpy` to project dependencies