### PR TITLE
Run `RawKNNClassifier._predict_fc` as parallel to avoid memory issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ pip install git+https://github.com/lemma-osu/gee-knn-python@main
 - numpy
 - pydantic
 - scikit-learn
-- scikit-learn-knn-regression @ git+https://github.com/lemma-osu/scikit-learn-knn-regression@main
+- sknnr @ git+https://github.com/lemma-osu/scikit-learn-knn-regression@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "numpy",
     "pydantic",
     "scikit-learn",
-    "scikit-learn-knn-regression @ git+https://github.com/lemma-osu/scikit-learn-knn-regression",
+    "sknnr @ git+https://github.com/lemma-osu/scikit-learn-knn-regression",
 ]
 
 [project.urls]

--- a/src/geeknn/_base.py
+++ b/src/geeknn/_base.py
@@ -168,7 +168,7 @@ class RawKNNClassifier:
     def _(
         self,
         fc: ee.FeatureCollection,
-        colocation_obj: Colocation | None = None,
+        colocation_obj: Optional[Colocation] = None,  # noqa: UP007
         num_threads: int = -1,
         chunk_size: int = 500,
     ):
@@ -201,7 +201,7 @@ class RawKNNClassifier:
         self,
         fc: ee.FeatureCollection,
         ids: NDArray,
-        colocation_obj: Colocation | None = None,
+        colocation_obj: Optional[Colocation] = None,  # noqa: UP007
         num_threads: int = -1,
         chunk_size: int = 500,
     ):


### PR DESCRIPTION
Closes #8 by creating a `joblib.Parallel` job to retrieve predictions for a feature collection.  Options are provided for specifying the size of the batch (`chunk_size`) and the number of threads to use (`num_threads`).  Once all neighbors are retrieved, the result is stitched back together into an `ee.FeatureCollection`.

Note that this is a way to do this *server-side*, but that may not be the best workflow for this use case.  Typically, one wants to run the feature collection mode to do cross-validation on the plots used to fit the model or run a new set of targets.  We are investigating the possibility of: 1) converting the feature collection client-side; and 2) using `sknnr` to run the prediction locally.

We will keep this PR open as we decide on the best path forward.